### PR TITLE
Replace `tj-actions/changed-files` with `step-security/changed-files`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v11.1
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         id: verify-changed-files
         with:
           files: |

--- a/.github/workflows/upload-source-documents.yml
+++ b/.github/workflows/upload-source-documents.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Verify Changed files
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           files: |
             website/**/*.mdx


### PR DESCRIPTION
Blogs: 
- https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066, 
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised.
- https://wails.io/blog/security-incident-response-march-2025

Smallstep repositories affected: https://github.com/search?q=org%3Asmallstep+uses%3A+tj-actions%2Fchanged-files%40v+language%3AYAML+path%3A.github%2F&type=code (just this one). No actions were run with the compromised version of the action, so no secrets were leaked.

The original `tj-actions` was removed for a bit, but seems to be back now: https://github.com/tj-actions/changed-files?tab=readme-ov-file#changed-files.

This PR includes the same changes as in https://github.com/wailsapp/wails/commit/ea2bfa9bcd3624a15ba75ec500fec9ddf5f2716e, replacing `tj-actions` with `step-security`.